### PR TITLE
🐛 get token at each api call, and remove in context

### DIFF
--- a/msa_sdk/msa_api.py
+++ b/msa_sdk/msa_api.py
@@ -39,7 +39,6 @@ class MSA_API():  # pylint: disable=invalid-name
     def __init__(self):
         """Initialize."""
         self.url = 'http://{}:{}/ubi-api-rest'.format(*host_port())
-        self._token = context['TOKEN']
         self.path = ""
         self.response = None
         self.log_response = True
@@ -142,7 +141,15 @@ class MSA_API():  # pylint: disable=invalid-name
         Token
 
         """
-        return self._token
+        try:
+            url = os.environ.get('API_TOKEN_URL') or "http://msa-auth:8080/auth/realms/main/protocol/openid-connect/token"
+            params = {"client_id": os.environ.get("CLIENT_ID"), "grant_type": "client_credentials", "client_secret" : os.environ.get("CLIENT_SECRET")}
+            response = requests.post(url, data=params)
+            data = response.json()
+            access_token = data["access_token"]
+        except Exception:
+            return "12345qwert"
+        return access_token
 
     @property
     def content(self):
@@ -180,7 +187,7 @@ class MSA_API():  # pylint: disable=invalid-name
         headers = {
             'Content-Type': 'application/json',
             'Accept': 'application/json',
-            'Authorization': 'Bearer {}'.format(self._token),
+            'Authorization': 'Bearer {}'.format(self.token),
         }
         self.add_trace_headers(headers)
         if data is None:
@@ -210,7 +217,7 @@ class MSA_API():  # pylint: disable=invalid-name
         """
         headers = {
             'Accept': 'application/json',
-            'Authorization': 'Bearer {}'.format(self._token),
+            'Authorization': 'Bearer {}'.format(self.token),
         }
         self.add_trace_headers(headers)
         url = self.url + self.path
@@ -237,7 +244,7 @@ class MSA_API():  # pylint: disable=invalid-name
         headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': 'Bearer {}'.format(self._token),
+            'Authorization': 'Bearer {}'.format(self.token),
         }
         self.add_trace_headers(headers)
         url = self.url + self.path
@@ -258,7 +265,7 @@ class MSA_API():  # pylint: disable=invalid-name
         """
         headers = {
             'Accept': 'application/json',
-            'Authorization': 'Bearer {}'.format(self._token),
+            'Authorization': 'Bearer {}'.format(self.token),
         }
         self.add_trace_headers(headers)
         url = self.url + self.path

--- a/msa_sdk/variables.py
+++ b/msa_sdk/variables.py
@@ -154,19 +154,7 @@ class Variables:
             if not ctx:
                 return context
             context = json.loads(ctx)
-
-        # Get Auth parameters.
-
-        try:
-            url = os.environ.get('API_TOKEN_URL') or "http://msa-auth:8080/auth/realms/main/protocol/openid-connect/token"
-            params = {"client_id": os.environ.get("CLIENT_ID"), "grant_type": "client_credentials", "client_secret" : os.environ.get("CLIENT_SECRET")}
-            response = requests.post(url, data=params)
-            data = response.json()
-            access_token = data["access_token"]
-            #-------------------------------------
-            context['TOKEN'] = access_token
-        except Exception:
-            context['TOKEN'] = "12345qwert"
+        context['TOKEN'] = "12345qwert"
         return context
 
 

--- a/tests/test_device_post.py
+++ b/tests/test_device_post.py
@@ -20,7 +20,7 @@ def test_activate(device_fixture):
     with patch('requests.post') as mock_call_post:
         device.activate()
         assert device.path == '/device/activate/{}'.format(device.device_id)
-        mock_call_post.assert_called_once()
+        mock_call_post.assert_called()
 
 
 def test_do_provisioningion(device_fixture):
@@ -33,7 +33,7 @@ def test_do_provisioningion(device_fixture):
         device.provision()
         assert device.path == '/device/provisioning/{}'.format(
             device.device_id)
-        mock_call_post.assert_called_once()
+        mock_call_post.assert_called()
 
 
 def test_update_config(device_fixture):
@@ -52,7 +52,7 @@ def test_update_config(device_fixture):
         assert _is_valid_json(device.update_config())
         assert device.path == '/device/configuration/update/{}'.format(
             device.device_id)
-        mock_call_post.assert_called_once()
+        mock_call_post.assert_called()
 
 
 def test_do_provisioning(device_fixture):
@@ -67,7 +67,7 @@ def test_do_provisioning(device_fixture):
 
         assert device.path == '/device/provisioning/{}'.format(
             device.device_id)
-        mock_call_post.assert_called_once()
+        mock_call_post.assert_called()
 
 
 def test_create(device_fixture):
@@ -87,7 +87,7 @@ def test_create(device_fixture):
         assert device.fail is not None
         assert not device.fail
 
-        mock_call_post.assert_called_once()
+        mock_call_post.assert_called()
 
 
 def test_create_fail(device_fixture):
@@ -137,7 +137,7 @@ def test_run_jsa_command_device(device_fixture):
       assert device.device_id == device_id
       assert not device.fail
 
-      mock_call_post.assert_called_once()
+      mock_call_post.assert_called()
 
 
 def test_run_jsa_command_device_empty_params(device_fixture):
@@ -161,7 +161,7 @@ def test_run_jsa_command_device_empty_params(device_fixture):
       assert device.device_id == device_id
       assert not device.fail
 
-      mock_call_post.assert_called_once()
+      mock_call_post.assert_called()
 
 
 
@@ -181,4 +181,4 @@ def test_set_tags(device_fixture):
         assert _is_valid_json(json.dumps(device.set_tags("TAG1:TAG2")))
         assert device.path == '/device/v2/67015/labels?labelValues=TAG1%3BTAG2'
 
-        mock_call_post.assert_called_once()
+        mock_call_post.assert_called()


### PR DESCRIPTION
Now the token is get just before the api call