### PR TITLE
Pierrerondel patch 3

### DIFF
--- a/msa_sdk/orchestration.py
+++ b/msa_sdk/orchestration.py
@@ -228,8 +228,7 @@ class Orchestration(MSA_API):
 
         """
         self.path = \
-            '/orchestration/{}/service/instance/{}'.format(self.ubiqube_id,
-                                                           service_id)
+            '/orchestration/v1/service/instance/{}'.format(service_id)
 
         self._call_delete()
 

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -167,7 +167,7 @@ def test_delete_service_by_id(orchestration_fixture):
     with patch('msa_sdk.msa_api.MSA_API._call_delete') as mock_call_delete:
         orch = orchestration_fixture
         orch.delete_service('1234')
-        assert orch.path == '/orchestration/MSAA19224/service/instance/1234'
+        assert orch.path == '/orchestration/v1/service/instance/1234'
         mock_call_delete.assert_called_once()
 
 


### PR DESCRIPTION
- change the endpoint of delete_service
- add a new endpoint:
       execute_delete_process(self, process_name: str, service_id: int):

- modify the test of delete_service